### PR TITLE
Add CS451 group project and Money Guy Show links

### DIFF
--- a/assets/db.json
+++ b/assets/db.json
@@ -135,6 +135,10 @@
             "url": "https://www.youtube.com/@StuffMadeHere"
           },
           {
+            "name": "The Money Guy Show",
+            "url": "https://www.youtube.com/channel/UC9vUu4vlIlMC0dHQCTvQPbg"
+          },
+          {
             "name": "Tom Scott",
             "url": "https://www.youtube.com/@TomScottGo"
           },
@@ -660,6 +664,12 @@
                   "category": "hackathon",
                   "link": "https://github.com/glowing-potato/graph-theory-game",
                   "title": "Graph Theory Game"
+                },
+                {
+                  "category": "school",
+                  "description": "https://raw.githubusercontent.com/Nate314/semester-group-project-cs451-group3/master/README.md",
+                  "link": "https://github.com/Nate314/semester-group-project-cs451-group3",
+                  "title": "CS451 Semester Group Project"
                 }
               ]
             }


### PR DESCRIPTION
## Summary
- Add CS451 semester group project repo link to Github Projects
- Add The Money Guy Show to youtube links
- Applied directly to the publish branch's assets/db.json (no rebuild needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)