### PR TITLE
Hide Card Games project, add Maple Leaf Rag video

### DIFF
--- a/src/assets/db.json
+++ b/src/assets/db.json
@@ -573,6 +573,12 @@
                   "description": "Sweden (Minecraft) played on keyboard.",
                   "link": "https://www.youtube.com/embed/YycTH3TATh8",
                   "title": "Sweden (Minecraft)"
+                },
+                {
+                  "category": "Other Projects",
+                  "description": "Maple Leaf Rag played on piano.",
+                  "link": "https://www.youtube.com/embed/MzouBBOcQ8s",
+                  "title": "Maple Leaf Rag"
                 }
               ]
             },

--- a/src/assets/db.json
+++ b/src/assets/db.json
@@ -644,6 +644,7 @@
                 {
                   "category": "personal",
                   "description": "https://raw.githubusercontent.com/Nate314/card-games/master/README.md",
+                  "hidden": true,
                   "link": "https://github.com/Nate314/card-games",
                   "title": "Card Games"
                 },


### PR DESCRIPTION
## Summary
- Marks the Card Games GitHub project entry as `hidden`, so it only appears once the site's secret unlock (Konami code) is active, matching the existing pattern used for other gated projects.
- Adds a new video entry for Maple Leaf Rag played on piano (https://youtu.be/MzouBBOcQ8s), styled after the existing Sweden (Minecraft) entry.