### PR TITLE
Hide Card Games project, add Maple Leaf Rag video

### DIFF
--- a/assets/db.json
+++ b/assets/db.json
@@ -573,6 +573,12 @@
                   "description": "Sweden (Minecraft) played on keyboard.",
                   "link": "https://www.youtube.com/embed/YycTH3TATh8",
                   "title": "Sweden (Minecraft)"
+                },
+                {
+                  "category": "Other Projects",
+                  "description": "Maple Leaf Rag played on piano.",
+                  "link": "https://www.youtube.com/embed/MzouBBOcQ8s",
+                  "title": "Maple Leaf Rag"
                 }
               ]
             },
@@ -644,6 +650,7 @@
                 {
                   "category": "personal",
                   "description": "https://raw.githubusercontent.com/Nate314/card-games/master/README.md",
+                  "hidden": true,
                   "link": "https://github.com/Nate314/card-games",
                   "title": "Card Games"
                 },


### PR DESCRIPTION
## Summary
Same content-only db.json change as #52, applied directly to the publish branch's assets/db.json:
- Marks the Card Games GitHub project entry as `hidden`, so it only appears once the site's secret unlock (Konami code) is active.
- Adds a new video entry for Maple Leaf Rag played on piano (https://youtu.be/MzouBBOcQ8s), styled after the existing Sweden (Minecraft) entry.